### PR TITLE
fix: guard empty URI in server metrics to avoid crash on malformed requests

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/core/Listeners.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/Listeners.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.function.Function;
 import jdk.net.ExtendedSocketOptions;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration;
@@ -204,7 +203,10 @@ public class Listeners {
             });
         }
         httpServer = httpServer
-                .metrics(true, Function.identity())
+                // Map empty/undecodable URIs to "/": on a decode failure reactor-netty hands an empty path to the
+                // metrics handler, which does path.substring(1) and throws. See reactor-netty 1.2.6
+                // https://github.com/reactor/reactor-netty/blob/b6e72c423245595c39ef00faa818e0109c96b57b/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerHttpServerMetricsHandler.java#L199
+                .metrics(true, uri -> uri == null || uri.isEmpty() ? "/" : uri)
                 .forwarded(ForwardedStrategy.of(config.forwardedStrategy(), config.trustedIps()))
                 .option(ChannelOption.SO_BACKLOG, config.soBacklog())
                 .childOption(ChannelOption.SO_KEEPALIVE, config.keepAlive())


### PR DESCRIPTION
## Summary

- Malformed inbound requests produce an empty path that reactor-netty's `MicrometerHttpServerMetricsHandler` passes to `path.substring(1)`, throwing on the epoll event loop while writing the 400:

  ```
  java.lang.StringIndexOutOfBoundsException: Range [1, 0) out of bounds for length 0
      at java.base/java.lang.String.substring(String.java:2807)
      at reactor.netty.http.server.MicrometerHttpServerMetricsHandler$ResponseTimeHandlerContext.<init>(MicrometerHttpServerMetricsHandler.java:199)
      at reactor.netty.http.server.MicrometerHttpServerMetricsHandler.startWrite(MicrometerHttpServerMetricsHandler.java)
      at reactor.netty.http.server.HttpServerOperations.sendDecodingFailures(HttpServerOperations.java)
      at reactor.netty.http.server.HttpTrafficHandler.channelRead(HttpTrafficHandler.java)
  ```
- Crash site: https://github.com/reactor/reactor-netty/blob/b6e72c423245595c39ef00faa818e0109c96b57b/reactor-netty-http/src/main/java/reactor/netty/http/server/MicrometerHttpServerMetricsHandler.java#L199

Replace the `uriTagValue` mapper at `Listeners.java` from `Function.identity()` with a guard that maps empty/null URIs to `"/"`, neutralizing the crash on the Carapace side without touching reactor-netty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where metrics handling could fail when processing empty or null URI paths. The system now properly normalizes these cases to "/" to ensure reliable metrics collection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NiccoMlt/carapaceproxy/pull/9?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
