### PR TITLE
fix: correct inverted safe-capacity check for cold backends

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthManager.java
@@ -270,7 +270,7 @@ public class BackendHealthManager implements Runnable {
             return false;
         }
         final BackendHealthStatus backendStatus = getBackendStatus(backendConfiguration.hostPort());
-        return backendConfiguration.safeCapacity() > backendStatus.getConnections();
+        return backendStatus.getConnections() > backendConfiguration.safeCapacity();
     }
 
     @VisibleForTesting


### PR DESCRIPTION
## Summary

- `BackendHealthManager.exceedsCapacity()` compared `safeCapacity() > connections`, returning `true` when a backend is **under** its safe capacity — the opposite of what the name and both callers expect.
- This inverts cold-backend rate limiting: in `SafeBackendSelector`, COLD backends within their limit were pushed to the back (`Long.MAX_VALUE - 1`) while overloaded ones kept normal priority; in `StandardEndpointMapper`, the "skip cold backend over safe capacity" branch fired for healthy backends instead.
- Fix compares the right way round: `connections > safeCapacity()`.