### PR TITLE
fix: preserve cached client SSL contexts across config reload

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
@@ -164,6 +164,7 @@ public class ProxyRequestsManager implements AutoCloseable {
                 final String path = backend.caCertificatePath();
                 if (!StringUtils.isBlank(path)) {
                     if (clientSslContexts.containsKey(path)) {
+                        newContexts.put(path, clientSslContexts.get(path));
                         LOGGER.debug("SSL context for backend {} was already loaded from {}", backend.id(), path);
                     } else {
                         final SslContext sslContext = parent.getTrustStoreManager()

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
@@ -163,7 +163,9 @@ public class ProxyRequestsManager implements AutoCloseable {
             for (final BackendConfiguration backend : newEndpoints) {
                 final String path = backend.caCertificatePath();
                 if (!StringUtils.isBlank(path)) {
-                    if (clientSslContexts.containsKey(path)) {
+                    if (newContexts.containsKey(path)) {
+                        LOGGER.debug("SSL context for backend {} was already prepared from {}", backend.id(), path);
+                    } else if (clientSslContexts.containsKey(path)) {
                         newContexts.put(path, clientSslContexts.get(path));
                         LOGGER.debug("SSL context for backend {} was already loaded from {}", backend.id(), path);
                     } else {

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
@@ -165,8 +165,11 @@ public class ProxyRequestsManager implements AutoCloseable {
                 if (!StringUtils.isBlank(path)) {
                     if (newContexts.containsKey(path)) {
                         LOGGER.debug("SSL context for backend {} was already prepared from {}", backend.id(), path);
-                    } else if (clientSslContexts.containsKey(path)) {
-                        newContexts.put(path, clientSslContexts.get(path));
+                        continue;
+                    }
+                    final SslContext cached = clientSslContexts.get(path);
+                    if (cached != null) {
+                        newContexts.put(path, cached);
                         LOGGER.debug("SSL context for backend {} was already loaded from {}", backend.id(), path);
                     } else {
                         final SslContext sslContext = parent.getTrustStoreManager()


### PR DESCRIPTION
## Summary

- `ProxyRequestsManager.reloadConfiguration()` rebuilds the `clientSslContexts` map from scratch on every reload. When a backend's `caCertificatePath` was already cached, the "already loaded" branch logged it but never copied the existing `SslContext` into the new map, so after `this.clientSslContexts = newContexts` the backend-specific CA was gone.
- At request time the lookup then misses and falls back to `DEFAULT_KEY` (the default trust store), silently dropping backend-specific CA trust — TLS handshake failures, or connections verified against the wrong anchor.
- Fix copies the cached context forward into the new map.

Only affects backends configured with a custom `caCertificatePath`; default-trust backends are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CA certificate SSL contexts are now preserved across configuration reloads so secure connections remain stable after reloads.
  * Duplicate CA certificate entries encountered during a reload are detected and skipped to avoid redundant work and reduce reload disruptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NiccoMlt/carapaceproxy/pull/11?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->