### PR TITLE
fix: stop mangling zookeeper client property names

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
@@ -795,7 +795,7 @@ public class HttpProxyServer implements AutoCloseable {
                 zkAddress = staticConfiguration.getString("zkAddress", "localhost:2181");
                 zkSecure = staticConfiguration.getBoolean("zkSecure", false);
                 zkTimeout = staticConfiguration.getInt("zkTimeout", 40_000);
-                zkProperties = new Properties(staticConfiguration.asProperties("zookeeper."));
+                zkProperties = new Properties(staticConfiguration.asProperties("zookeeper"));
                 LOG.info("mode=cluster, zkAddress=\"{}\", zkTimeout={}, peer.id=\"{}\", zkSecure: {}", zkAddress, zkTimeout, peerId, zkSecure);
                 zkProperties.forEach((k, v) -> LOG.info("additional zkclient property: {}={}", k, v));
                 break;


### PR DESCRIPTION
## Summary

- `ConfigurationStore.asProperties(prefix)` strips `prefix.length() + 1` characters from each matching key — the `+ 1` drops the dot separator, which is only correct when the caller passes the prefix **without** a trailing dot (the codebase convention; `forEach`/`findMaxIndexForPrefix` append the `.` themselves).
- The cluster-mode caller passed `"zookeeper."` **with** a trailing dot, so for `zookeeper.clientCnxnSocket` it took `substring(11)` = `lientCnxnSocket` — every custom `zookeeper.*` client property had its name's first letter eaten and was silently ignored by the ZK client.
- Fix passes `"zookeeper"` (no dot), matching the working `"db"` caller. The shared `asProperties` method is left untouched.

Dormant unless custom `zookeeper.*` properties are set; most deployments rely on ZK defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected ZooKeeper configuration property initialization in cluster mode to ensure proper loading of settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NiccoMlt/carapaceproxy/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->