### PR TITLE
fix: decrement pending-request counters exactly once per request

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
@@ -442,8 +442,6 @@ public class ProxyRequestsManager implements AutoCloseable {
                         );
                     }
                 }).doAfterResponseSuccess((resp, conn) -> {
-                    PENDING_REQUESTS_GAUGE.dec();
-                    healthStatus.decrementConnections();
                     endpointStats.getLastActivity().set(System.currentTimeMillis());
                 });
 
@@ -544,9 +542,6 @@ public class ProxyRequestsManager implements AutoCloseable {
                         }
                     }));
                 }).onErrorResume(err -> { // custom endpoint request/response error handling
-                    PENDING_REQUESTS_GAUGE.dec();
-                    healthStatus.decrementConnections();
-
                     final EndpointKey endpoint = EndpointKey.make(request.getAction().getHost(), request.getAction().getPort());
                     if (err instanceof ReadTimeoutException) {
                         STUCK_REQUESTS_COUNTER.inc();
@@ -566,6 +561,11 @@ public class ProxyRequestsManager implements AutoCloseable {
                         );
                     }
                     return serveServiceUnavailable(request);
+                })
+                // decrement once per request: success and error callbacks can both fire (headers ok, body fails)
+                .doFinally(signal -> {
+                    PENDING_REQUESTS_GAUGE.dec();
+                    healthStatus.decrementConnections();
                 });
     }
 


### PR DESCRIPTION
## Summary

- The request was counted up once (`PENDING_REQUESTS_GAUGE.inc()` + `healthStatus.incrementConnections()`), but decremented in **two** separate terminal callbacks: `doAfterResponseSuccess` and `onErrorResume`.
- Per reactor-netty, `doAfterResponseSuccess` fires on the response success signal while `onErrorResume` fires on a body-stream error. A request where the backend returns headers OK but then fails mid-body triggers **both** → two decrements against one increment.
- Effect: `PENDING_REQUESTS_GAUGE` (no floor) drifts negative over time, and `healthStatus.connections` undercounts, skewing `SafeBackendSelector` ordering and `exceedsCapacity`.
- Fix removes the decrement from both callbacks and does it once in `doFinally` on the returned publisher, which fires exactly once on any terminal signal. This also covers cancellation, which previously decremented nothing (a slow upward leak).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where request metrics were being incorrectly double-decremented under certain conditions, ensuring accurate tracking of active proxy connections and proper health status monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NiccoMlt/carapaceproxy/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->