### PR TITLE
fix: publish shared configuration fields volatile

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
@@ -173,23 +173,23 @@ public class HttpProxyServer implements AutoCloseable {
     private OcspStaplingManager ocspStaplingManager;
 
     @Getter
-    private RuntimeServerConfiguration currentConfiguration;
+    private volatile RuntimeServerConfiguration currentConfiguration;
 
     @Getter
     private ConfigurationStore dynamicConfigurationStore;
 
     @Getter
-    private EndpointMapper mapper;
+    private volatile EndpointMapper mapper;
 
     @Getter
     @Setter
-    private UserRealm realm;
+    private volatile UserRealm realm;
 
     @Getter
     private final TrustStoreManager trustStoreManager;
 
     @Getter
-    private List<RequestFilter> filters;
+    private volatile List<RequestFilter> filters;
     private volatile boolean started;
 
     @Getter


### PR DESCRIPTION
## Summary

`HttpProxyServer` carries four references that get **rewritten during a runtime config reload** and **read on every request** by Netty event-loop threads:

| Field | Declared | Rewritten by `applyDynamicConfiguration` | Read on hot path |
|---|---|---|---|
| `currentConfiguration` | `HttpProxyServer.java:176` | line 770 | `ProxyRequestsManager:419,433,570,635`, `StandardEndpointMapper.map:162`, `Listeners.bootListener:223,236`, … |
| `mapper` | `:182` | line 760 | `ProxyRequestsManager.processRequest:219` (every request) |
| `realm` | `:186` | line 757 | authentication filters |
| `filters` | `:192` | line 749 | `ProxyRequestsManager.processRequest:211` (every request) |

The four writes live inside `configurationLock.tryLock()` (lines 741-770), but **no reader acquires that lock** — they go through Lombok `@Getter` accessors, which compile to a plain `getfield` + `areturn` (verified with `javap`; only `started` carries the `ACC_VOLATILE` flag in the class file).

Per the JMM, there is no happens-before edge between the reload's writes and the readers' reads:
- `configurationLock` only establishes HB between successive writer threads, not to readers.
- The interleaved `listeners.reloadConfiguration` does perform `ConcurrentHashMap` ops that piggyback-publish `filters` (written at 749, before the call), but `realm` / `mapper` / `currentConfiguration` are written **after** that call and have no further synchronization action behind them.
- So a Netty I/O thread is not guaranteed to ever observe the post-reload `mapper`, `realm`, or `currentConfiguration`. On x86 + current HotSpot this rarely manifests (TSO drains the store buffer fast, and HotSpot does not cache plain reads across the virtual call into `getMapper()`), which is why the bug shows no signature in production logs. On weakly-ordered architectures (AArch64 — Graviton, Apple Silicon) stale reads can persist meaningfully longer.

This is an old bug, predating Carapace v2.x by ~7 years (the four fields existed without `volatile` since v1.0.0; the relevant commits are 2017-08-28 `dfceff48` and 2018-10-02 `6d9218e4` "Reload configuration without restart" — which introduced `configurationLock` itself).

### Why only these four

Every other reassignable field on `HttpProxyServer` is either:
- written **once in the constructor** (e.g. `backendHealthManager`, `dynamicCertificatesManager`, `ocspStaplingManager`, `proxyRequestsManager`, …) — safely published to event-loop threads via the thread-start happens-before edge when `listeners.start()` spins up the loops; or
- written **once at boot** inside `applyStaticConfiguration` (e.g. `dynamicConfigurationStore`, `groupMembershipHandler`, ZK fields) — also before listener bind; or
- gated by `if (started) throw` so it can only be invoked pre-boot (`addRequestFilter` at line 619).

The `@Setter` annotations on `backendHealthManager` / `dynamicCertificatesManager` / `ocspStaplingManager` / `realm` aren't called from anywhere in the codebase, so they don't introduce additional runtime-write paths (cosmetic cleanup, out of scope here).

### Fix

Add `volatile` to the four fields. Lombok `@Getter` becomes a fence-respecting read; the write side already runs under `configurationLock` and is unchanged. Four-token change, negligible perf cost (one fence on read vs. cache-line bouncing on write are both lost in the noise on this path that already crosses several virtual calls).

### Out of scope

- Cross-field atomicity (a reader can still observe new `mapper` + old `filters` mid-reload). That's BUG-07 (split-brain config), and the fix there is build-then-swap, not volatile.
- Visibility of `RuntimeServerConfiguration` *contents* (subfields read via the volatile root reference) — those are themselves writable but mostly settled before the reference becomes visible; revisit if any specific subfield turns out to race.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal stability of the proxy server's core components to ensure more reliable operation under concurrent load.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NiccoMlt/carapaceproxy/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->