### PR TITLE
fix: log access on publisher terminate, not assembly

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ProxyRequestsManager.java
@@ -226,22 +226,20 @@ public class ProxyRequestsManager implements AutoCloseable {
             LOGGER.trace("{} Mapped {} to {}, userid {}", this, request.getUri(), action, request.getUserId());
         }
 
-        try {
-            return switch (action.getAction()) {
-                case NOTFOUND -> serveNotFoundMessage(request);
-                case INTERNAL_ERROR -> serveInternalErrorMessage(request);
-                case SERVICE_UNAVAILABLE -> serveServiceUnavailable(request);
-                case MAINTENANCE_MODE -> serveMaintenanceMessage(request);
-                case BAD_REQUEST -> serveBadRequestMessage(request);
-                case STATIC, ACME_CHALLENGE -> serveStaticMessage(request);
-                case REDIRECT -> serveRedirect(request);
-                case PROXY -> forward(request, false, action.getHealthStatus());
-                case CACHE -> serveFromCache(request, action.getHealthStatus()); // cached content
-                default -> throw new IllegalStateException("Action " + action.getAction() + " not supported");
-            };
-        } finally {
-            parent.getRequestsLogger().logRequest(request);
-        }
+        final Publisher<Void> result = switch (action.getAction()) {
+            case NOTFOUND -> serveNotFoundMessage(request);
+            case INTERNAL_ERROR -> serveInternalErrorMessage(request);
+            case SERVICE_UNAVAILABLE -> serveServiceUnavailable(request);
+            case MAINTENANCE_MODE -> serveMaintenanceMessage(request);
+            case BAD_REQUEST -> serveBadRequestMessage(request);
+            case STATIC, ACME_CHALLENGE -> serveStaticMessage(request);
+            case REDIRECT -> serveRedirect(request);
+            case PROXY -> forward(request, false, action.getHealthStatus());
+            case CACHE -> serveFromCache(request, action.getHealthStatus()); // cached content
+            default -> throw new IllegalStateException("Action " + action.getAction() + " not supported");
+        };
+        // Log on terminal signal so response status, backend timing, and cache info are populated.
+        return Mono.from(result).doFinally(sig -> parent.getRequestsLogger().logRequest(request));
     }
 
     private Publisher<Void> serveNotFoundMessage(ProxyRequest request) {


### PR DESCRIPTION
## Summary

`ProxyRequestsManager.processRequest()` returns `Publisher<Void>`. The previous code wrapped the per-action `switch` in a `try { return … } finally { parent.getRequestsLogger().logRequest(request); }`. Because `finally` fires when the publisher is **assembled** (i.e. the moment the method returns), not when reactor-netty later subscribes and the request actually completes, the access-log call happened *before* the request had been served.

Effects:
- `PROXY` (the common path): no response status, no backend timing, no response size in the log entry — those are populated reactively in `forward(…)` after the entry has already been written.
- `CACHE`: hit/miss tracking populated in `serveFromCache`'s reactive chain — also missed.
- Synchronous actions (`NOTFOUND`, `BAD_REQUEST`, `REDIRECT`, `MAINTENANCE_MODE`, `INTERNAL_ERROR`, `SERVICE_UNAVAILABLE`, `STATIC`, `ACME_CHALLENGE`) sometimes set the response status synchronously inside their case body so that field may land correctly, but the response-write completion and the final `lastActivity` happen reactively, so the duration logged is the assembly time, not the wire time.

Net: every access log entry was systematically incomplete for the proxied/cached majority of traffic; entries for synchronous actions were only partially right.

Fix moves the logging into the reactive chain:

```java
return Mono.from(result).doFinally(sig -> parent.getRequestsLogger().logRequest(request));
```

`doFinally` fires exactly once on any terminal signal (complete, error, cancel) of the returned publisher, so logging happens after the request has actually terminated and `request` carries its final state. Same shape that PR #13 applied to the pending-request counter decrement.

One behavior change at the edges: if a case's body throws **synchronously during assembly** (today the only path is the `default -> throw new IllegalStateException`), no log entry is emitted with this fix. The previous code logged an unfinished request in that case. Acceptable — assembly-time exceptions indicate broken internal state, not a real request to log.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal request processing handling with enhanced reactive signal management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NiccoMlt/carapaceproxy/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->