### PR TITLE
fix: clamp connections counter atomically on decrement

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthStatus.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthStatus.java
@@ -136,9 +136,10 @@ public class BackendHealthStatus {
     }
 
     public void decrementConnections() {
-        if (this.connections.getAcquire() > 0) {
-            this.connections.decrementAndGet();
-        }
+        // Clamp at 0 atomically: reportAsUnreachable resets the counter via set(0), so in-flight
+        // decrements that arrive afterwards would otherwise underflow. A bare check-then-decrement
+        // is non-atomic and can race with concurrent decrements or set(0).
+        this.connections.updateAndGet(v -> Math.max(0, v - 1));
     }
 
     public void setWarmupPeriod(final long warmupPeriod) {


### PR DESCRIPTION
## Summary

`BackendHealthStatus.decrementConnections` decomposed "decrement, clamped at 0" into two separate atomic ops:

```java
if (this.connections.getAcquire() > 0) {   // CHECK
    this.connections.decrementAndGet();    // USE
}
```

Each call is atomic; their composition is not — the canonical TOCTOU shape. Any other writer that touches `connections` between the read and the decrement falsifies the guard.

The two concurrent writers that actually trigger it:

1. **Another `decrementConnections`** from a parallel request completion. With both reading the same `1` and both passing the guard, the second `decrementAndGet` lands at `-1`. Frequent on master because of BUG-10 (the double-decrement consolidated in PR #13); rarer after that fix, but still possible on simultaneous request completions.
2. **`reportAsUnreachable` calling `this.connections.set(0)`** at line 94 when a backend flips to DOWN. If an in-flight decrement has passed the guard and is about to execute, `set(0)` lands first, then the pending `decrementAndGet` drives the counter to `-1`. This case survives the BUG-10 fix and is the load-bearing reason the guard exists at all.

Negative counts distort the consumers:
- `SafeBackendSelector.connections(...)` sorts COLD backends by this value — negative values would push a DOWN-recovering COLD backend to artificially first place.
- `BackendHealthManager.exceedsCapacity` (corrected in PR #10) compares `connections > safeCapacity`; a negative count makes "exceeds capacity" trivially false, defeating the warmup rate-limiter.

### Fix

```java
public void decrementConnections() {
    this.connections.updateAndGet(v -> Math.max(0, v - 1));
}
```

`AtomicInteger.updateAndGet(IntUnaryOperator)` is a CAS loop that re-applies the operator on every retry, so the read, the `Math.max` clamp, and the decrement happen as a single linearization point. Any concurrent writer (another decrement, `set(0)`, or an increment) is observed before the function is reapplied, and the result is always `≥ 0`.

The `getAcquire()` was the only VarHandle-style op in the codebase; with the new shape it's no longer needed (the CAS loop does its own atomic read). Inline comment captures the *why* of the clamp.

### Note

The clamp is defensive against the `set(0)` reset in `reportAsUnreachable`. With normally-balanced inc/dec (post PR #13), the counter wouldn't underflow without that reset; the `set(0)` itself is debatable design (it discards in-flight requests' eventual decrements and forces the clamp here). That redesign belongs with BUG-09 (the broader race on `BackendHealthStatus`'s multi-field transitions). For BUG-16's scope, the atomic clamp is the correct surgical fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected backend connection counter behavior under concurrent operations to prevent incorrect counts and ensure stable backend health monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NiccoMlt/carapaceproxy/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->