### PR TITLE
fix: isolate per-listener reload failures and shorten dispose timeout

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/core/Listeners.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/Listeners.java
@@ -151,23 +151,37 @@ public class Listeners {
         // apply new configuration, this has to be done before rebooting listeners
         currentConfiguration = newConfiguration;
 
+        // Per-listener try/catch isolates failures (e.g. disposeChannel timeouts, bad cert in bootListener)
+        // so one listener cannot cascade into halting the whole reload. InterruptedException still aborts.
         try {
             for (final EndpointKey hostPort : listenersToStop) {
                 LOG.info("Stopping {}", hostPort);
-                stopListener(hostPort);
+                try {
+                    stopListener(hostPort);
+                } catch (final RuntimeException ex) {
+                    LOG.error("Failed to stop listener {}", hostPort, ex);
+                }
             }
 
             for (final EndpointKey hostPort : listenersToRestart) {
                 LOG.info("Restart {}", hostPort);
-                stopListener(hostPort);
-                final var newConfigurationForListener = currentConfiguration.getListener(hostPort);
-                bootListener(newConfigurationForListener);
+                try {
+                    stopListener(hostPort);
+                    final var newConfigurationForListener = currentConfiguration.getListener(hostPort);
+                    bootListener(newConfigurationForListener);
+                } catch (final ConfigurationNotValidException | RuntimeException ex) {
+                    LOG.error("Failed to restart listener {}", hostPort, ex);
+                }
             }
 
             for (final EndpointKey hostPort : listenersToStart) {
                 LOG.info("Starting {}", hostPort);
-                final var newConfigurationForListener = currentConfiguration.getListener(hostPort);
-                bootListener(newConfigurationForListener);
+                try {
+                    final var newConfigurationForListener = currentConfiguration.getListener(hostPort);
+                    bootListener(newConfigurationForListener);
+                } catch (final ConfigurationNotValidException | RuntimeException ex) {
+                    LOG.error("Failed to start listener {}", hostPort, ex);
+                }
             }
         } catch (final InterruptedException stopMe) {
             Thread.currentThread().interrupt();

--- a/carapace-server/src/main/java/org/carapaceproxy/core/Listeners.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/Listeners.java
@@ -294,6 +294,8 @@ public class Listeners {
             } catch (InterruptedException ex) {
                 LOG.error("Interrupted while stopping a listener", ex);
                 Thread.currentThread().interrupt();
+            } catch (RuntimeException ex) {
+                LOG.error("Failed to stop listener {}", key, ex);
             }
         }
     }

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ListeningChannel.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ListeningChannel.java
@@ -93,8 +93,10 @@ public class ListeningChannel {
     }
 
     public void disposeChannel() {
-        this.channel.disposeNow(Duration.ofSeconds(10));
-        FutureMono.from(this.config.group().close()).block(Duration.ofSeconds(10));
+        // 2s timeouts: a longer wait can't drain HTTP/2 connections that the client keeps idle anyway,
+        // and overlapping a 10s+ stall with a 30s certificate-rotation cycle stalls the reload pipeline.
+        this.channel.disposeNow(Duration.ofSeconds(2));
+        FutureMono.from(this.config.group().close()).block(Duration.ofSeconds(2));
     }
 
     public void incRequests() {

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ListeningChannel.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ListeningChannel.java
@@ -95,8 +95,13 @@ public class ListeningChannel {
     public void disposeChannel() {
         // 2s timeouts: a longer wait can't drain HTTP/2 connections that the client keeps idle anyway,
         // and overlapping a 10s+ stall with a 30s certificate-rotation cycle stalls the reload pipeline.
-        this.channel.disposeNow(Duration.ofSeconds(2));
-        FutureMono.from(this.config.group().close()).block(Duration.ofSeconds(2));
+        // Always attempt the event-loop group close in a finally so a disposeNow timeout doesn't leak it;
+        // the group close itself can still throw IllegalStateException, callers must guard accordingly.
+        try {
+            this.channel.disposeNow(Duration.ofSeconds(2));
+        } finally {
+            FutureMono.from(this.config.group().close()).block(Duration.ofSeconds(2));
+        }
     }
 
     public void incRequests() {


### PR DESCRIPTION
## Summary

`Listeners.reloadConfiguration` wraps the stop/restart/start loops in a single `try { … } catch (final InterruptedException stopMe)` block. The body of `disposeChannel` does two `Mono.block(Duration.ofSeconds(10))` calls — both of which can throw an unchecked `IllegalStateException: Timeout on blocking read for 10000000000 NANOSECONDS` when child channels don't drain in time. The catch doesn't cover that, so the exception escapes the loop and halts every remaining listener for the current reload.

Confirmed live: the staging server log shows ~296 of those stack traces in 40 hours, with the dynamic-certificate manager retrying every 30 seconds and failing to release the mutex cleanly about half the time (~1,069 `Failed to acquire lock for executeInMutex` entries vs ~2,138 invocations). Same shape applies to a `ConfigurationNotValidException` from `bootListener` after a stale or malformed cert — one bad listener would take down all the listeners after it in the same reload.

### Changes

- Wrap each iteration of the three loops (`listenersToStop`, `listenersToRestart`, `listenersToStart`) in its own `try { … } catch (final ConfigurationNotValidException | RuntimeException ex) { LOG.error(...); }`. A failure in one listener is logged and the loop moves on; the rest of the listeners and the cert-manager cycle complete normally. The outer `InterruptedException` handling is unchanged (interruption still aborts the whole reload).
- Drop both `disposeChannel` block timeouts from 10s to 2s. The cert-rotation cycle runs every ~30s; a 10s stall per disposal stacks up against that budget for no real benefit because reactor-netty force-closes after the timeout anyway. 2s is enough for a healthy drain and stops the timer from being eaten by stalled disposals.

### Out of scope (deferred)

- Making `disposeChannel` truly non-blocking by chaining the `Mono` instead of `block()`ing. That turns the reload pipeline into a reactive chain and is a larger refactor; CLAUDE.md flags it as the eventual correct shape. Tracked for a follow-up.
- Rollback for partially-failed restarts. Today, if a listener stops successfully but `bootListener` fails, the per-listener catch logs the error and the listener remains down until the next reload detects it (the next config change or the next cert-rotation cycle, both routine). Acceptable interim behavior; a proper "rollback to old config on partial failure" would belong with the broader BUG-07 (split-brain config-reload) work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration reload now isolates failures per listener so one listener's error or stop failure is logged without aborting the whole reload.
  * Listener stop failures are caught and logged instead of escaping the stop sequence.

* **Performance**
  * Shorter shutdown timeouts to speed up channel disposal and reduce delays during reloads and restarts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NiccoMlt/carapaceproxy/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->