### PR TITLE
fix: stage config view fields and commit them only after subsystem reloads

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/HttpProxyServer.java
@@ -742,11 +742,14 @@ public class HttpProxyServer implements AutoCloseable {
             throw new ConfigurationChangeInProgressException();
         }
         try {
+            // Build everything as locals first; do not touch the four `this.X` view fields yet.
             RuntimeServerConfiguration newConfiguration = buildValidConfiguration(storeWithConfig);
             EndpointMapper newMapper = buildMapper(newConfiguration.getMapperClassname(), this, storeWithConfig);
             UserRealm newRealm = buildRealm(userRealmClassname, storeWithConfig);
+            List<RequestFilter> newFilters = buildFilters(newConfiguration);
 
-            this.filters = buildFilters(newConfiguration);
+            // Reload subsystems. Any of these can throw; if it does, the four view fields below
+            // are left untouched, so request-time readers keep seeing a coherent old snapshot.
             this.backendHealthManager.reloadConfiguration(newConfiguration, newMapper);
             this.dynamicCertificatesManager.reloadConfiguration(newConfiguration);
             this.trustStoreManager.reloadConfiguration(newConfiguration);
@@ -754,10 +757,8 @@ public class HttpProxyServer implements AutoCloseable {
             this.listeners.reloadConfiguration(newConfiguration);
             this.cache.reloadConfiguration(newConfiguration);
             this.requestsLogger.reloadConfiguration(newConfiguration);
-            this.realm = newRealm;
             Map<String, BackendConfiguration> currentBackends = mapper != null ? mapper.getBackends() : Collections.emptyMap();
             Map<String, BackendConfiguration> newBackends = newMapper.getBackends();
-            this.mapper = newMapper;
 
             if (!newBackends.equals(currentBackends) || isConnectionsConfigurationChanged(newConfiguration)) {
                 proxyRequestsManager.reloadConfiguration(newConfiguration, newBackends.values());
@@ -767,6 +768,12 @@ public class HttpProxyServer implements AutoCloseable {
                 dynamicConfigurationStore.commitConfiguration(newConfigurationStore);
             }
 
+            // Commit point: every subsystem has reloaded and persistence succeeded; swap the four
+            // view fields back-to-back so the cross-field tearing window observed by readers shrinks
+            // from the full subsystem-reload duration to a handful of volatile writes.
+            this.filters = newFilters;
+            this.realm = newRealm;
+            this.mapper = newMapper;
             this.currentConfiguration = newConfiguration;
         } catch (ConfigurationNotValidException err) {
             // impossible to have a non valid configuration here


### PR DESCRIPTION
## Summary

`HttpProxyServer.applyDynamicConfiguration` wrote the four request-time view fields (`filters`, `realm`, `mapper`, `currentConfiguration`) interleaved with seven subsystem `reloadConfiguration(...)` calls, with no staging or rollback. Any of those subsystem calls can throw — `ConfigurationNotValidException` from a bad cert/backend, or any unchecked exception bubbling out of reactor-netty, ZK, or OpenSSL native code — and when one does, the fields that were assigned earlier stay, the ones that come after don't, and request readers observe a torn combination of new and old config indefinitely.

Concrete examples of the resulting split-brain reader view, by throw point:

| throws at | `this.filters` | `this.realm` | `this.mapper` | `this.currentConfiguration` |
|---|---|---|---|---|
| `backendHealthManager.reloadConfiguration` | **new** | old | old | old |
| `listeners.reloadConfiguration` | **new** | old | old | old |
| `proxyRequestsManager.reloadConfiguration` (after the `this.mapper = newMapper` line) | **new** | **new** | **new** | old |
| `dynamicConfigurationStore.commitConfiguration` (DB persistence) | **new** | **new** | **new** | old (and the new config is **not persisted**, so a process restart silently rolls back) |

The catch at line 771 says *"impossible to have a non valid configuration here"* — that's wrong. `buildValidConfiguration` does validate at line 745, but the delegated subsystem reloads can themselves throw `ConfigurationNotValidException` at runtime (and any unchecked exception bypasses the catch entirely).

### Changes

- Build `newFilters` as a local instead of `this.filters = …` at line 749.
- Move the four `this.X = newX` writes (`filters`, `realm`, `mapper`, `currentConfiguration`) to a single block at the end of the `try`, after every subsystem `reloadConfiguration(...)` and the DB commit have returned successfully.
- Comments mark the staging area and the commit point.

Behavior of the subsystem reloads is unchanged; the order in which they run is unchanged; the field-write order is unchanged. The only difference is that none of the four `this.X` writes happen until every step before them has succeeded.

### What this does and doesn't cover

- **Does**: eliminates the cross-field tearing window observed by request-time readers. If any subsystem reload throws, the four view fields are untouched and readers see a coherent old snapshot. With BUG-06 already making the four fields `volatile` (NiccoMlt/carapaceproxy#15), the four writes are also each fence-respecting; the residual tearing across the four is now a handful of volatile stores back-to-back, instead of the full subsystem-reload duration as before.
- **Doesn't**: address subsystem-level inconsistency. `BackendHealthManager` may have re-pointed to the new mapper while `Listeners` is still on the old config when the throw happens — that's the same surface as the BUG-08 "rollback on partial reload" follow-up, and the right fix is a two-phase `prepare → commit/abort` across every reloadable subsystem. Tracked separately; would naturally land alongside the non-blocking-disposal refactor flagged for BUG-08.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of dynamic configuration application to ensure consistent server behavior during updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NiccoMlt/carapaceproxy/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->