### PR TITLE
test: poll PENDING_REQUESTS_GAUGE until terminal fires

### DIFF
--- a/carapace-server/src/test/java/org/carapaceproxy/backends/StuckRequestsTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/StuckRequestsTest.java
@@ -42,6 +42,7 @@ import org.carapaceproxy.server.config.ActionConfiguration;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration;
 import org.carapaceproxy.server.mapper.StandardEndpointMapper;
 import org.carapaceproxy.utils.RawHttpClient;
+import org.carapaceproxy.utils.TestUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -125,6 +126,7 @@ public class StuckRequestsTest {
                         """, resp.getBodyString());
             }
 
+            TestUtils.waitForCondition(() -> ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get() == 0, 10);
             assertThat((int) ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get(), is(0));
             assertThat((int) ProxyRequestsManager.STUCK_REQUESTS_COUNTER.get() > 0, is(true));
 

--- a/carapace-server/src/test/java/org/carapaceproxy/backends/UnreachableBackendTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/backends/UnreachableBackendTest.java
@@ -42,6 +42,7 @@ import org.carapaceproxy.server.config.ActionConfiguration;
 import org.carapaceproxy.server.config.NetworkListenerConfiguration;
 import org.carapaceproxy.utils.RawHttpClient;
 import org.carapaceproxy.utils.TestEndpointMapper;
+import org.carapaceproxy.utils.TestUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -101,6 +102,7 @@ public class UnreachableBackendTest {
                         """, resp.getBodyString());
             }
             assertSame(BackendHealthStatus.Status.DOWN, server.getBackendHealthManager().getBackendStatus(key).getStatus());
+            TestUtils.waitForCondition(() -> ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get() == 0, 10);
             assertThat((int) ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get(), is(0));
         }
     }
@@ -156,6 +158,7 @@ public class UnreachableBackendTest {
                         """, resp.getBodyString());
             }
             assertSame(COLD, server.getBackendHealthManager().getBackendStatus(key).getStatus()); // no troubles for new connections
+            TestUtils.waitForCondition(() -> ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get() == 0, 10);
             assertThat((int) ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get(), is(0));
         }
     }
@@ -188,6 +191,7 @@ public class UnreachableBackendTest {
                         """, resp.getBodyString());
             }
             assertSame(COLD, server.getBackendHealthManager().getBackendStatus(key).getStatus()); // no troubles for new connections
+            TestUtils.waitForCondition(() -> ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get() == 0, 10);
             assertThat((int) ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get(), is(0));
         }
     }
@@ -241,6 +245,7 @@ public class UnreachableBackendTest {
                         """, resp.getBodyString());
             }
             assertSame(COLD, server.getBackendHealthManager().getBackendStatus(key).getStatus());
+            TestUtils.waitForCondition(() -> ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get() == 0, 10);
             assertThat((int) ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get(), is(0));
         }
     }


### PR DESCRIPTION
## Summary

After #13 was merged, `UnreachableBackendTest.testNonHttpResponseThenClose[useCache=false]` started failing intermittently on Linux CI:

```
java.lang.AssertionError:
Expected: is <0>
     but: was <1>
```

Root cause: #13 moved the `PENDING_REQUESTS_GAUGE.dec()` call from inside `onErrorResume` (which fires synchronously on the event loop when the error is detected, **before** the 503 fallback is written) into `doFinally` on the returned publisher (which fires after `sendResponseData` completes). The dec now lands on the event-loop thread **after** the test client has already read the response and the test thread has proceeded to the assertion. With no happens-before edge between the two, `PENDING_REQUESTS_GAUGE.get()` can still observe `1` when the assertion runs.

The race is real for any error-path test that reads the gauge after the client read but before the publisher terminates. The five assertion sites in `UnreachableBackendTest` (4) and `StuckRequestsTest` (1) all share this shape; only `testNonHttpResponseThenClose` has surfaced so far because its error path (`RANDOM_DATA_THEN_CLOSE` — backend writes garbage then closes) is the slowest one, widening the window.

### Changes

Wrap each gauge assertion with `TestUtils.waitForCondition` so the test waits up to 10 s for the publisher's `doFinally` to land before asserting:

```java
TestUtils.waitForCondition(() -> ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get() == 0, 10);
assertThat((int) ProxyRequestsManager.PENDING_REQUESTS_GAUGE.get(), is(0));
```

Two-line idiom matches the existing pattern (`TestUtils.waitForCondition` does the polling; the trailing `assertThat` keeps the failure message informative if the wait times out). Production code is not touched — #13's behavior (single decrement on terminal, including cancel) is intentional and correct; the tests were relying on a synchronous-dec timing side-effect that #13 legitimately changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test stability for request handling scenarios by adding explicit synchronization checks to ensure pending requests are properly cleared before assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NiccoMlt/carapaceproxy/pull/20?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->