### PR TITLE
fix: make BackendHealthStatus transitions atomic via AtomicReference<State>

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/api/BackendsResource.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/api/BackendsResource.java
@@ -96,9 +96,10 @@ public class BackendsResource {
             }
             BackendHealthStatus bhs = backendsSnapshot.get(key);
             if (bhs != null) {
-                bean.available = bhs.getStatus() != BackendHealthStatus.Status.DOWN;
-                bean.reportedAsUnreachable = bhs.getStatus() == BackendHealthStatus.Status.DOWN;
-                bean.reportedAsUnreachableTs = bhs.getUnreachableSince();
+                final BackendHealthStatus.Snapshot snap = bhs.snapshot();
+                bean.available = snap.status() != BackendHealthStatus.Status.DOWN;
+                bean.reportedAsUnreachable = snap.status() == BackendHealthStatus.Status.DOWN;
+                bean.reportedAsUnreachableTs = snap.unreachableSince();
                 BackendHealthCheck lastProbe = bhs.getLastProbe();
                 if (lastProbe != null) {
                     bean.lastProbeTs = lastProbe.endTs();

--- a/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthStatus.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthStatus.java
@@ -21,6 +21,7 @@ package org.carapaceproxy.server.backends;
 
 import java.sql.Timestamp;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.carapaceproxy.core.EndpointKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,35 +38,33 @@ public class BackendHealthStatus {
     private final EndpointKey hostPort;
     private final AtomicInteger connections;
 
-    private volatile Status status;
-    private volatile long unreachableSince;
-    private volatile long lastUnreachable;
-    private volatile long lastReachable;
+    // Status + the three associated timestamps move together via a single AtomicReference so concurrent
+    // reportAs(Un)Reachable callers cannot leave the four fields in a torn combination (e.g. status=DOWN
+    // with unreachableSince=0). Configuration knobs (warmupPeriod) and the periodic probe handle
+    // (lastProbe) stay as separate volatile fields — they aren't part of the transition's atom.
+    private final AtomicReference<State> state;
     private volatile BackendHealthCheck lastProbe;
     private volatile long warmupPeriod;
 
     public BackendHealthStatus(final EndpointKey hostPort, final long warmupPeriod) {
         this.hostPort = hostPort;
         // we assume that the backend just became reachable when the status is created
-        this.status = Status.COLD;
-        this.unreachableSince = 0L;
         final long created = System.currentTimeMillis();
-        this.lastUnreachable = created;
-        this.lastReachable = created;
+        this.state = new AtomicReference<>(new State(Status.COLD, 0L, created, created));
         this.connections = new AtomicInteger();
         this.warmupPeriod = warmupPeriod;
     }
 
     public long getUnreachableSince() {
-        return unreachableSince;
+        return state.get().unreachableSince();
     }
 
     public long getLastUnreachable() {
-        return lastUnreachable;
+        return state.get().lastUnreachable();
     }
 
     public long getLastReachable() {
-        return lastReachable;
+        return state.get().lastReachable();
     }
 
     public EndpointKey getHostPort() {
@@ -81,48 +80,34 @@ public class BackendHealthStatus {
     }
 
     public Status getStatus() {
-        return status;
+        return state.get().status();
     }
 
     public void reportAsUnreachable(final long timestamp, final String cause) {
         LOG.info("{}: reportAsUnreachable {}, cause {}", hostPort, new Timestamp(timestamp), cause);
-        if (this.status != Status.DOWN) {
-            this.status = Status.DOWN;
-            this.unreachableSince = timestamp;
-        }
-        this.lastUnreachable = timestamp;
-        this.connections.set(0);
+        state.updateAndGet(s -> s.withUnreachable(timestamp));
+        // The historical connections.set(0) reset has been dropped: with the inc/dec invariant
+        // restored (NiccoMlt/carapaceproxy#13 — single decrement on terminal) and the atomic
+        // clamp (#17), in-flight requests' decrements drain the counter naturally; SafeBackendSelector
+        // already ignores `connections` for DOWN backends, so the value while DOWN is irrelevant.
     }
 
     public void reportAsReachable(final long timestamp) {
         LOG.debug("{}: reportAsReachable {}", hostPort, new Timestamp(timestamp));
-        switch (this.status) {
-            case DOWN:
-                this.status = Status.COLD;
-                this.unreachableSince = 0;
-                this.lastReachable = timestamp;
-                break;
-            case COLD:
-                this.lastReachable = timestamp;
-                if (this.lastReachable - this.lastUnreachable > this.warmupPeriod) {
-                    this.status = Status.STABLE;
-                }
-                break;
-            case STABLE:
-                this.lastReachable = timestamp;
-                break;
-        }
+        final long warmup = this.warmupPeriod;
+        state.updateAndGet(s -> s.withReachable(timestamp, warmup));
     }
 
     @Override
     public String toString() {
+        final State snapshot = state.get();
         return "BackendHealthStatus{"
                 + " hostPort=" + this.hostPort
                 + ", connections=" + this.connections
-                + ", status=" + this.status
-                + ", unreachableSince=" + this.unreachableSince
-                + ", unreachableUntil=" + this.lastUnreachable
-                + ", lastReachable=" + this.lastReachable
+                + ", status=" + snapshot.status()
+                + ", unreachableSince=" + snapshot.unreachableSince()
+                + ", unreachableUntil=" + snapshot.lastUnreachable()
+                + ", lastReachable=" + snapshot.lastReachable()
                 + ", lastProbe=" + this.lastProbe
                 + '}';
     }
@@ -164,5 +149,34 @@ public class BackendHealthStatus {
          * The backend is reachable and was so since a reasonably-long time.
          */
         STABLE
+    }
+
+    /**
+     * Immutable snapshot of the four state-machine fields that transition together.
+     * Held in an {@link AtomicReference} so {@code reportAs(Un)Reachable} callers cannot interleave their
+     * field writes; each {@link AtomicReference#updateAndGet} call is a single linearization point.
+     */
+    private record State(Status status, long unreachableSince, long lastUnreachable, long lastReachable) {
+        State withUnreachable(final long timestamp) {
+            if (status == Status.DOWN) {
+                // Already DOWN; just refresh lastUnreachable, preserve unreachableSince.
+                return new State(status, unreachableSince, timestamp, lastReachable);
+            }
+            // Transition from COLD/STABLE to DOWN.
+            return new State(Status.DOWN, timestamp, timestamp, lastReachable);
+        }
+
+        State withReachable(final long timestamp, final long warmupPeriod) {
+            return switch (status) {
+                case DOWN -> new State(Status.COLD, 0L, lastUnreachable, timestamp);
+                case COLD -> {
+                    // Warmup check uses a coherent (lastUnreachable, timestamp) pair from this snapshot,
+                    // so concurrent reportAsUnreachable cannot move lastUnreachable between the two reads.
+                    final Status next = (timestamp - lastUnreachable) > warmupPeriod ? Status.STABLE : Status.COLD;
+                    yield new State(next, unreachableSince, lastUnreachable, timestamp);
+                }
+                case STABLE -> new State(Status.STABLE, unreachableSince, lastUnreachable, timestamp);
+            };
+        }
     }
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthStatus.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/backends/BackendHealthStatus.java
@@ -83,6 +83,17 @@ public class BackendHealthStatus {
         return state.get().status();
     }
 
+    /**
+     * Returns a coherent snapshot of the four state-machine fields ({@code status}, {@code unreachableSince},
+     * {@code lastUnreachable}, {@code lastReachable}). Use this instead of calling several field-level getters
+     * in a row when more than one field is needed — each individual getter is itself atomic, but two
+     * consecutive getter calls can straddle a state transition and observe an inconsistent pair.
+     */
+    public Snapshot snapshot() {
+        final State s = state.get();
+        return new Snapshot(s.status(), s.unreachableSince(), s.lastUnreachable(), s.lastReachable());
+    }
+
     public void reportAsUnreachable(final long timestamp, final String cause) {
         LOG.info("{}: reportAsUnreachable {}, cause {}", hostPort, new Timestamp(timestamp), cause);
         state.updateAndGet(s -> s.withUnreachable(timestamp));
@@ -152,7 +163,14 @@ public class BackendHealthStatus {
     }
 
     /**
-     * Immutable snapshot of the four state-machine fields that transition together.
+     * Coherent read-only view of {@link #getStatus()}, {@link #getUnreachableSince()},
+     * {@link #getLastUnreachable()}, and {@link #getLastReachable()} captured atomically via {@link #snapshot()}.
+     */
+    public record Snapshot(Status status, long unreachableSince, long lastUnreachable, long lastReachable) {
+    }
+
+    /**
+     * Immutable internal record of the four state-machine fields that transition together.
      * Held in an {@link AtomicReference} so {@code reportAs(Un)Reachable} callers cannot interleave their
      * field writes; each {@link AtomicReference#updateAndGet} call is a single linearization point.
      */


### PR DESCRIPTION
## Summary

`BackendHealthStatus.reportAsReachable` and `reportAsUnreachable` mutated four `volatile` fields (`status`, `unreachableSince`, `lastUnreachable`, `lastReachable`) across multi-step bodies with no synchronization. `volatile` makes each individual write visible, but it does not make a group of writes atomic, so concurrent callers (the health-check timer thread + Netty event-loop threads that call `reportBackendUnreachable` on connection errors) could interleave and leave the four fields in a torn combination.

Concrete failure modes the previous layout permitted:

| interleaving | end state | invariant broken |
|---|---|---|
| `reportAsReachable` runs `status=COLD`, yields; concurrent `reportAsUnreachable` runs `status=DOWN; unreachableSince=t2`; first call resumes with `unreachableSince=0` | `status=DOWN, unreachableSince=0` | "DOWN ⇒ unreachableSince > 0" |
| `reportAsUnreachable` sets `status=DOWN`, yields before `unreachableSince=t1`; concurrent `reportAsReachable` (DOWN branch) sets `status=COLD, unreachableSince=0`; first call resumes with `unreachableSince=t1` | `status=COLD, unreachableSince=t1` | "COLD ⇒ unreachableSince = 0" |
| COLD branch reads `lastReachable - lastUnreachable` as two separate `volatile` ops; concurrent `reportAsUnreachable` writes `lastUnreachable` between them | warmup-bypass / phantom-stable | BUG-17's warmup-promotion logic |
| two concurrent `reportAsUnreachable` callers both pass `if (status != DOWN)` | double DOWN transition, doubled `LOG.info`, doubled `connections.set(0)` race | minor, but amplifies the BUG-16 race |

These corrupt states surface as nonsensical "DOWN since" durations in the admin UI / metrics, distorted warmup behaviour, and unreliable inputs to `SafeBackendSelector` and `exceedsCapacity`.

### Changes

- Replace the four `volatile` state fields with a `private final AtomicReference<State> state`, where `State` is an immutable record carrying the four fields together.
- `reportAsUnreachable` and `reportAsReachable` use `AtomicReference.updateAndGet(s -> s.withUnreachable(...))` / `withReachable(...)` so each transition is a single linearization point. The CAS loop re-applies the transition on every retry, so a concurrent writer is always observed before the next iteration's decision.
- The warmup check (`COLD → STABLE`) now reads `timestamp - lastUnreachable` from the same snapshot used to write the result, eliminating the BUG-17-adjacent two-volatile read tear inside that branch.
- Getters (`getStatus`, `getUnreachableSince`, `getLastUnreachable`, `getLastReachable`) read the single `AtomicReference` and return the corresponding record component, so each field read is a snapshot rather than a fresh `volatile`. `toString` snapshots once at the start so its output is coherent.
- `lastProbe` and `warmupPeriod` stay as separate `volatile` fields — they aren't part of the state-machine atom.

### Drop `connections.set(0)` from `reportAsUnreachable`

Following the queued reconsideration from #17's PR description: with #13 restoring the inc/dec invariant (single decrement on terminal) and #17 making the clamp atomic, in-flight requests' decrements drain the counter naturally on their way out. `SafeBackendSelector` already returns `Long.MAX_VALUE` for DOWN backends, so the value of `connections` while DOWN doesn't influence routing; on recovery to COLD the counter is at-or-near 0. The `set(0)` reset was the load-bearing reason the clamp in `decrementConnections` existed at all (was needed to swallow in-flight decs after the reset). The clamp stays as defensive dead code; can be pruned in a later sweep.

### Out of scope

Reader-side multi-field tearing is still possible if a caller reads two getters separately (each is an atomic snapshot, but two consecutive calls may straddle a transition). Exposing a `snapshot()` method that returns the full record and migrating the few multi-field readers (`BackendsResource` reads `status` then `unreachableSince`) belongs in a separate, smaller pass — flagged for follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Backend health tracking rewritten for atomic, thread-safe state updates and coherent snapshots of reachability and timestamps.
  * Health exposure now reads from a consistent snapshot, ensuring API-reported availability and unreachable timestamps are stable and race-free.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NiccoMlt/carapaceproxy/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->