### PR TITLE
Skip listener reload when no certificate binding actually changed

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/configstore/CertificateData.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/configstore/CertificateData.java
@@ -21,6 +21,7 @@ package org.carapaceproxy.configstore;
 
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.REQUEST_FAILED;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
@@ -114,6 +115,34 @@ public class CertificateData {
                     Optional.ofNullable(subjectAltNames).stream().flatMap(Set::stream)
                 )
                 .collect(Collectors.toUnmodifiableSet());
+    }
+
+    /**
+     * Tells whether two certificates would bind identically on a TLS listener.
+     * <p>
+     * Compares only the binding-relevant fields: the decoded keystore bytes and the
+     * subject-alternative-name set. Differences in transient ACME state such as
+     * {@code state}, {@code attemptsCount}, {@code message}, or {@code pendingOrderLocation}
+     * are ignored, because those tick on every failing renewal attempt without changing
+     * what the listener actually serves.
+     * <p>
+     * The Lombok-generated {@link #equals(Object)} cannot be used here: it includes
+     * {@code attemptsCount} and {@code message}, so a stuck ACME order would report
+     * "changed" on every poll, defeating any reload-guard built on top of it.
+     *
+     * @param a a certificate (nullable)
+     * @param b a certificate (nullable)
+     * @return {@code true} if both are null, or if both carry the same keystore bytes and SANs
+     */
+    public static boolean bindingEquivalent(final CertificateData a, final CertificateData b) {
+        if (a == b) {
+            return true;
+        }
+        if (a == null || b == null) {
+            return false;
+        }
+        return Arrays.equals(a.getKeystoreData(), b.getKeystoreData())
+                && Objects.equals(a.getSubjectAltNames(), b.getSubjectAltNames());
     }
 
     /**

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
@@ -105,7 +105,7 @@ public class DynamicCertificatesManager implements Runnable {
     private static final String EVENT_CERTIFICATES_STATE_CHANGED = "certificates_state_changed";
     private static final String EVENT_CERTIFICATES_REQUEST_STORE = "certificates_request_store";
 
-    private Map<String, CertificateData> certificates = new ConcurrentHashMap<>();
+    private volatile Map<String, CertificateData> certificates = new ConcurrentHashMap<>();
     private ACMEClient acmeClient; // Let's Encrypt client
     private Route53Client r53Client;
     private String awsAccessKey;
@@ -373,8 +373,9 @@ public class DynamicCertificatesManager implements Runnable {
         }
         if (flushCache) {
             groupMembershipHandler.fireEvent(EVENT_CERTIFICATES_STATE_CHANGED, null);
-            // remember that events  are not delivered to the local JVM
-            reloadCertificatesFromDB();
+            // remember that events  are not delivered to the local JVM;
+            // already running inside the mutex via certificatesLifecycle's caller, so skip the dispatcher.
+            reloadCertificatesFromDBInternal();
         }
     }
 
@@ -668,7 +669,19 @@ public class DynamicCertificatesManager implements Runnable {
         }
     }
 
+    /**
+     * Dispatcher entry point: serialises reloads across the scheduler thread, ZK callbacks,
+     * and the admin REST path through {@link GroupMembershipHandler#executeInMutex}, which
+     * is reentrant per-thread in both standalone and cluster modes.
+     * <p>
+     * Callers already running inside the mutex (e.g. {@link #certificatesLifecycle()})
+     * should invoke {@link #reloadCertificatesFromDBInternal()} directly instead.
+     */
     private void reloadCertificatesFromDB() {
+        groupMembershipHandler.executeInMutex(THREAD_NAME, period > 0 ? period : 1, this::reloadCertificatesFromDBInternal);
+    }
+
+    private void reloadCertificatesFromDBInternal() {
         LOG.info("Reloading certificates from db");
         try {
             Map<String, CertificateData> newCertificates = new ConcurrentHashMap<>();
@@ -681,13 +694,31 @@ public class DynamicCertificatesManager implements Runnable {
                 LOG.info("RELOADED certificate for domain {}: {}", domain, freshCert);
             }
             var oldCertificates = this.certificates;
+            final boolean anyBindingChange = hasAnyBindingChange(oldCertificates, newCertificates);
             this.certificates = newCertificates; // only certificates/domains specified in the config have to be managed.
-            server.getListeners().reloadCurrentConfiguration();
+            if (anyBindingChange) {
+                server.getListeners().reloadCurrentConfiguration();
+            } else {
+                LOG.debug("No certificate binding change detected; skipping listener reload");
+            }
             // storing certificates on local path
             storeLocalCertificates(newCertificates.values(), oldCertificates);
         } catch (GeneralSecurityException | MalformedURLException | InterruptedException | ConfigurationNotValidException e) {
             throw new DynamicCertificatesManagerException("Unable to load dynamic certificates from db.", e);
         }
+    }
+
+    static boolean hasAnyBindingChange(final Map<String, CertificateData> oldCertificates,
+                                       final Map<String, CertificateData> newCertificates) {
+        if (!oldCertificates.keySet().equals(newCertificates.keySet())) {
+            return true;
+        }
+        for (final Entry<String, CertificateData> entry : newCertificates.entrySet()) {
+            if (!CertificateData.bindingEquivalent(oldCertificates.get(entry.getKey()), entry.getValue())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void storeLocalCertificates(Collection<CertificateData> newCertificates, Map<String, CertificateData> oldCertificates) {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
@@ -674,11 +674,19 @@ public class DynamicCertificatesManager implements Runnable {
      * and the admin REST path through {@link GroupMembershipHandler#executeInMutex}, which
      * is reentrant per-thread in both standalone and cluster modes.
      * <p>
+     * Falls back to a direct call when {@link #groupMembershipHandler} has not been attached
+     * yet (test runs, local-only setups), matching the null-guard pattern used elsewhere in
+     * this class (e.g. {@link #run()} and {@link #setStateOfCertificate}).
+     * <p>
      * Callers already running inside the mutex (e.g. {@link #certificatesLifecycle()})
      * should invoke {@link #reloadCertificatesFromDBInternal()} directly instead.
      */
     private void reloadCertificatesFromDB() {
-        groupMembershipHandler.executeInMutex(THREAD_NAME, period > 0 ? period : 1, this::reloadCertificatesFromDBInternal);
+        if (groupMembershipHandler != null) {
+            groupMembershipHandler.executeInMutex(THREAD_NAME, period > 0 ? period : 1, this::reloadCertificatesFromDBInternal);
+        } else {
+            reloadCertificatesFromDBInternal();
+        }
     }
 
     private void reloadCertificatesFromDBInternal() {

--- a/carapace-server/src/test/java/org/carapaceproxy/configstore/CertificateDataBindingEquivalentTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/configstore/CertificateDataBindingEquivalentTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.carapaceproxy.configstore;
+
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.AVAILABLE;
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.REQUEST_FAILED;
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.WAITING;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import java.net.URI;
+import java.util.Set;
+import org.junit.Test;
+
+public class CertificateDataBindingEquivalentTest {
+
+    private static final byte[] KEYSTORE_A = {0x01, 0x02, 0x03};
+    private static final byte[] KEYSTORE_B = {0x04, 0x05, 0x06};
+    private static final Set<String> SANS_A = Set.of("alt-a.example.com");
+    private static final Set<String> SANS_B = Set.of("alt-b.example.com");
+
+    @Test
+    public void testBothNullReturnsTrue() {
+        assertTrue(CertificateData.bindingEquivalent(null, null));
+    }
+
+    @Test
+    public void testOneNullReturnsFalse() {
+        final CertificateData cert = buildCert(KEYSTORE_A, SANS_A);
+        assertFalse(CertificateData.bindingEquivalent(cert, null));
+        assertFalse(CertificateData.bindingEquivalent(null, cert));
+    }
+
+    @Test
+    public void testSameReferenceReturnsTrue() {
+        final CertificateData cert = buildCert(KEYSTORE_A, SANS_A);
+        assertTrue(CertificateData.bindingEquivalent(cert, cert));
+    }
+
+    @Test
+    public void testIdenticalKeystoreAndSansReturnsTrueDespiteTransientState() throws Exception {
+        // Staging symptom: a stuck ACME order ticks attemptsCount/message/state/pendingOrderLocation
+        // every poll while keystore bytes and SANs stay the same.
+        final CertificateData stable = buildCert(KEYSTORE_A, SANS_A);
+        stable.setState(AVAILABLE);
+        stable.setAttemptsCount(0);
+        stable.setMessage("");
+        stable.setPendingOrderLocation(null);
+
+        final CertificateData ticked = buildCert(KEYSTORE_A.clone(), SANS_A);
+        ticked.setState(REQUEST_FAILED);
+        ticked.setAttemptsCount(11);
+        ticked.setMessage("stuck order");
+        ticked.setPendingOrderLocation(URI.create("https://acme/order/42").toURL());
+
+        assertTrue(CertificateData.bindingEquivalent(stable, ticked));
+    }
+
+    @Test
+    public void testKeystoreBytesDifferReturnsFalse() {
+        final CertificateData a = buildCert(KEYSTORE_A, SANS_A);
+        final CertificateData b = buildCert(KEYSTORE_B, SANS_A);
+        assertFalse(CertificateData.bindingEquivalent(a, b));
+    }
+
+    @Test
+    public void testKeystoreNullVsBytesReturnsFalse() {
+        final CertificateData a = buildCert(null, SANS_A);
+        final CertificateData b = buildCert(KEYSTORE_A, SANS_A);
+        assertFalse(CertificateData.bindingEquivalent(a, b));
+    }
+
+    @Test
+    public void testSubjectAltNamesDifferReturnsFalse() {
+        final CertificateData a = buildCert(KEYSTORE_A, SANS_A);
+        final CertificateData b = buildCert(KEYSTORE_A, SANS_B);
+        assertFalse(CertificateData.bindingEquivalent(a, b));
+    }
+
+    private static CertificateData buildCert(final byte[] keystoreData, final Set<String> sans) {
+        final CertificateData cert = new CertificateData("example.com", sans, null, WAITING, null, null);
+        cert.setKeystoreData(keystoreData);
+        return cert;
+    }
+}

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerReloadGuardTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerReloadGuardTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.carapaceproxy.server.certificates;
+
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.AVAILABLE;
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.REQUEST_FAILED;
+import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.hasAnyBindingChange;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import java.util.Map;
+import java.util.Set;
+import org.carapaceproxy.configstore.CertificateData;
+import org.junit.Test;
+
+/**
+ * Tests for the listener-reload gate added in {@link DynamicCertificatesManager#hasAnyBindingChange}.
+ * Each test name describes the high-level behaviour driven by the predicate: when it returns
+ * {@code false}, the reload skips {@code server.getListeners().reloadCurrentConfiguration()}.
+ */
+public class DynamicCertificatesManagerReloadGuardTest {
+
+    private static final byte[] KEYSTORE_A = {0x10, 0x11, 0x12};
+    private static final byte[] KEYSTORE_B = {0x20, 0x21, 0x22};
+
+    @Test
+    public void testReloadSkipsListenerWhenNoCertChanged() {
+        final CertificateData stable = certWithKeystore("example.com", KEYSTORE_A);
+        final Map<String, CertificateData> old = Map.of("example.com", stable);
+        final Map<String, CertificateData> fresh = Map.of("example.com", certWithKeystore("example.com", KEYSTORE_A.clone()));
+        assertFalse(hasAnyBindingChange(old, fresh));
+    }
+
+    @Test
+    public void testReloadTriggersListenerOnKeystoreChange() {
+        final Map<String, CertificateData> old = Map.of("example.com", certWithKeystore("example.com", KEYSTORE_A));
+        final Map<String, CertificateData> fresh = Map.of("example.com", certWithKeystore("example.com", KEYSTORE_B));
+        assertTrue(hasAnyBindingChange(old, fresh));
+    }
+
+    @Test
+    public void testReloadTriggersListenerOnDomainAdded() {
+        final Map<String, CertificateData> old = Map.of("example.com", certWithKeystore("example.com", KEYSTORE_A));
+        final Map<String, CertificateData> fresh = Map.of(
+                "example.com", certWithKeystore("example.com", KEYSTORE_A.clone()),
+                "second.example.com", certWithKeystore("second.example.com", KEYSTORE_B));
+        assertTrue(hasAnyBindingChange(old, fresh));
+    }
+
+    @Test
+    public void testReloadTriggersListenerOnDomainRemoved() {
+        final Map<String, CertificateData> old = Map.of(
+                "example.com", certWithKeystore("example.com", KEYSTORE_A),
+                "second.example.com", certWithKeystore("second.example.com", KEYSTORE_B));
+        final Map<String, CertificateData> fresh = Map.of("example.com", certWithKeystore("example.com", KEYSTORE_A.clone()));
+        assertTrue(hasAnyBindingChange(old, fresh));
+    }
+
+    @Test
+    public void testReloadSkipsListenerWhenOnlyAttemptsCountIncremented() {
+        // Exact staging symptom: a stuck ACME order ticks attemptsCount+message+state every poll
+        // while keystoreData stays at its last successful value (or null on a brand-new domain).
+        final CertificateData stuckPrev = certWithKeystore("stuck.example.com", null);
+        stuckPrev.setState(REQUEST_FAILED);
+        stuckPrev.setAttemptsCount(10);
+        stuckPrev.setMessage("Challenge response verification failed, status is INVALID");
+
+        final CertificateData stuckTicked = certWithKeystore("stuck.example.com", null);
+        stuckTicked.setState(REQUEST_FAILED);
+        stuckTicked.setAttemptsCount(11);
+        stuckTicked.setMessage("Challenge response verification failed, status is INVALID");
+
+        final Map<String, CertificateData> old = Map.of("stuck.example.com", stuckPrev);
+        final Map<String, CertificateData> fresh = Map.of("stuck.example.com", stuckTicked);
+        assertFalse(hasAnyBindingChange(old, fresh));
+    }
+
+    @Test
+    public void testReloadTriggersListenerOnSanChange() {
+        final CertificateData oldCert = certWithKeystoreAndSans("example.com", KEYSTORE_A, Set.of("alt.example.com"));
+        final CertificateData freshCert = certWithKeystoreAndSans("example.com", KEYSTORE_A.clone(), Set.of("other.example.com"));
+        final Map<String, CertificateData> old = Map.of("example.com", oldCert);
+        final Map<String, CertificateData> fresh = Map.of("example.com", freshCert);
+        assertTrue(hasAnyBindingChange(old, fresh));
+    }
+
+    private static CertificateData certWithKeystore(final String domain, final byte[] keystoreData) {
+        return certWithKeystoreAndSans(domain, keystoreData, null);
+    }
+
+    private static CertificateData certWithKeystoreAndSans(final String domain, final byte[] keystoreData, final Set<String> sans) {
+        final CertificateData cert = new CertificateData(domain, sans, null, AVAILABLE, null, null);
+        cert.setKeystoreData(keystoreData);
+        return cert;
+    }
+}


### PR DESCRIPTION
## Context

`DynamicCertificatesManager.reloadCertificatesFromDB()` fires `Listeners.reloadCurrentConfiguration()` after every poll and every ZK `certificates_state_changed` event, and the classification then short-circuits on reference equality of the config object — every SSL listener restarts each cycle regardless of whether any of its bound certs changed. A single stuck ACME order, `attemptsCount` ticking per poll, keeps the cycle running indefinitely.

## Approach

Trigger the listener reload only when at least one cert's binding state (keystore bytes, SANs) actually changed; skip otherwise. Lombok's auto-`equals` cannot drive this because it counts transient ACME bookkeeping. Also serialise concurrent reload paths (admin REST + ZK callbacks + scheduler) through the same `executeInMutex` already used by `certificatesLifecycle`, and publish the cert map `volatile` for Netty readers.

Listener-side scope narrowing — when the trigger does fire, the broad reload still restarts every SSL listener — ships separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Certificate management now detects meaningful binding changes and only reloads listeners when needed, reducing unnecessary restarts.
* **Bug Fixes**
  * Improved reload reliability to avoid re-entry issues and ensure updated certificates are applied correctly.
* **Tests**
  * Added unit tests covering equivalence logic and reload-skip/trigger scenarios to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NiccoMlt/carapaceproxy/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->