### PR TITLE
Restart only the SSL listeners whose bound certificates actually changed

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/core/Listeners.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/Listeners.java
@@ -34,6 +34,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import jdk.net.ExtendedSocketOptions;
@@ -104,12 +105,35 @@ public class Listeners {
 
     /**
      * Apply a new configuration and refresh the listeners according to it.
+     * <p>
+     * Equivalent to {@link #reloadConfiguration(RuntimeServerConfiguration, Set)} with a
+     * {@code null} {@code changedCertIds} — broad path: every SSL listener falls into
+     * the restart bucket when the new configuration is the same reference as the current
+     * one (the historical sentinel used by the certificate manager).
      *
      * @param newConfiguration the configuration
      * @throws InterruptedException if it is interrupted while starting or stopping a listener
      * @see #reloadCurrentConfiguration()
      */
     void reloadConfiguration(final RuntimeServerConfiguration newConfiguration) throws InterruptedException, ConfigurationNotValidException {
+        reloadConfiguration(newConfiguration, null);
+    }
+
+    /**
+     * Apply a new configuration and refresh only the listeners whose bound certificates
+     * actually changed.
+     * <p>
+     * When {@code changedCertIds} is non-null, the certificate-change branch of the
+     * classification matches a listener only if at least one of its bound SNI certs
+     * appears in the supplied set (see {@link ListeningChannel#bindsAnyOf(Set)}).
+     * When {@code changedCertIds} is {@code null}, the historical reference-equality
+     * sentinel is used instead.
+     *
+     * @param newConfiguration the configuration
+     * @param changedCertIds   certificate ids whose binding-relevant state has changed; may be {@code null}
+     * @throws InterruptedException if it is interrupted while starting or stopping a listener
+     */
+    void reloadConfiguration(final RuntimeServerConfiguration newConfiguration, final Set<String> changedCertIds) throws InterruptedException, ConfigurationNotValidException {
         if (!started) {
             this.currentConfiguration = newConfiguration;
             return;
@@ -125,7 +149,11 @@ public class Listeners {
             final EndpointKey hostPort = channel.getKey();
             final NetworkListenerConfiguration actualListenerConfig = currentConfiguration.getListener(hostPort);
             final NetworkListenerConfiguration newConfigurationForListener = newConfiguration.getListener(hostPort);
-            final boolean isReloadCertificate = newConfiguration == currentConfiguration && newConfigurationForListener.ssl();
+            final boolean isReloadCertificate = newConfigurationForListener != null
+                    && newConfigurationForListener.ssl()
+                    && (changedCertIds != null
+                            ? channel.getValue().bindsAnyOf(changedCertIds)
+                            : newConfiguration == currentConfiguration);
             if (newConfigurationForListener == null) {
                 LOG.info("listener: {} is to be shut down", hostPort);
                 listenersToStop.add(hostPort);
@@ -302,11 +330,25 @@ public class Listeners {
 
     /**
      * Re-apply the current configuration; it should be invoked after editing it.
+     * <p>
+     * Broad path: every SSL listener is restarted. For the narrow path used by the
+     * dynamic certificate manager, see {@link #reloadCurrentConfiguration(Set)}.
      *
      * @throws InterruptedException if it is interrupted while starting or stopping a listener
      */
     public void reloadCurrentConfiguration() throws InterruptedException, ConfigurationNotValidException {
         reloadConfiguration(this.currentConfiguration);
+    }
+
+    /**
+     * Re-apply the current configuration, restarting only the SSL listeners whose bound
+     * certs appear in {@code changedCertIds}.
+     *
+     * @param changedCertIds certificate ids whose binding-relevant state has changed
+     * @throws InterruptedException if it is interrupted while starting or stopping a listener
+     */
+    public void reloadCurrentConfiguration(final Set<String> changedCertIds) throws InterruptedException, ConfigurationNotValidException {
+        reloadConfiguration(this.currentConfiguration, changedCertIds);
     }
 
 }

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ListeningChannel.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ListeningChannel.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import javax.net.ssl.KeyManagerFactory;
 import org.carapaceproxy.server.config.ConfigurationNotValidException;
@@ -110,6 +111,24 @@ public class ListeningChannel {
 
     public void clear() {
         this.sslContexts.clear();
+    }
+
+    /**
+     * Tells whether this listener binds at least one of the supplied certificate ids.
+     * <p>
+     * The {@link #sslContexts} map is keyed by certificate id, so its key set is the
+     * authoritative bound-cert set for this listener. Used by
+     * {@link Listeners#reloadConfiguration(RuntimeServerConfiguration, Set)} to skip the
+     * restart of listeners whose bound certs did not change.
+     *
+     * @param changedCertIds certificate ids whose binding-relevant state has changed; may be {@code null} or empty
+     * @return {@code true} when at least one of the supplied ids appears in {@link #sslContexts}
+     */
+    public boolean bindsAnyOf(final Set<String> changedCertIds) {
+        if (changedCertIds == null || changedCertIds.isEmpty()) {
+            return false;
+        }
+        return !Collections.disjoint(this.sslContexts.keySet(), changedCertIds);
     }
 
     private SslContext bootSslContext(final NetworkListenerConfiguration listener, final SSLCertificateConfiguration certificate) throws ConfigurationNotValidException {

--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
@@ -51,6 +51,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -702,10 +703,10 @@ public class DynamicCertificatesManager implements Runnable {
                 LOG.info("RELOADED certificate for domain {}: {}", domain, freshCert);
             }
             var oldCertificates = this.certificates;
-            final boolean anyBindingChange = hasAnyBindingChange(oldCertificates, newCertificates);
+            final Set<String> changedCertIds = computeChangedCertIds(oldCertificates, newCertificates);
             this.certificates = newCertificates; // only certificates/domains specified in the config have to be managed.
-            if (anyBindingChange) {
-                server.getListeners().reloadCurrentConfiguration();
+            if (!changedCertIds.isEmpty()) {
+                server.getListeners().reloadCurrentConfiguration(changedCertIds);
             } else {
                 LOG.debug("No certificate binding change detected; skipping listener reload");
             }
@@ -716,17 +717,25 @@ public class DynamicCertificatesManager implements Runnable {
         }
     }
 
-    static boolean hasAnyBindingChange(final Map<String, CertificateData> oldCertificates,
-                                       final Map<String, CertificateData> newCertificates) {
-        if (!oldCertificates.keySet().equals(newCertificates.keySet())) {
-            return true;
-        }
+    /**
+     * Cert ids whose binding-relevant state (keystore bytes, SANs) differs between the
+     * previous and refreshed cert maps, plus any newly-added or removed ids. An empty
+     * return means no listener restart is needed.
+     */
+    static Set<String> computeChangedCertIds(final Map<String, CertificateData> oldCertificates,
+                                             final Map<String, CertificateData> newCertificates) {
+        final Set<String> changed = new HashSet<>();
         for (final Entry<String, CertificateData> entry : newCertificates.entrySet()) {
             if (!CertificateData.bindingEquivalent(oldCertificates.get(entry.getKey()), entry.getValue())) {
-                return true;
+                changed.add(entry.getKey());
             }
         }
-        return false;
+        for (final String oldKey : oldCertificates.keySet()) {
+            if (!newCertificates.containsKey(oldKey)) {
+                changed.add(oldKey);
+            }
+        }
+        return changed;
     }
 
     private void storeLocalCertificates(Collection<CertificateData> newCertificates, Map<String, CertificateData> oldCertificates) {

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerReloadGuardTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerReloadGuardTest.java
@@ -21,8 +21,8 @@ package org.carapaceproxy.server.certificates;
 
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.AVAILABLE;
 import static org.carapaceproxy.server.certificates.DynamicCertificateState.REQUEST_FAILED;
-import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.hasAnyBindingChange;
-import static org.junit.Assert.assertFalse;
+import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.computeChangedCertIds;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import java.util.Map;
 import java.util.Set;
@@ -30,9 +30,10 @@ import org.carapaceproxy.configstore.CertificateData;
 import org.junit.Test;
 
 /**
- * Tests for the listener-reload gate added in {@link DynamicCertificatesManager#hasAnyBindingChange}.
- * Each test name describes the high-level behaviour driven by the predicate: when it returns
- * {@code false}, the reload skips {@code server.getListeners().reloadCurrentConfiguration()}.
+ * Tests for the listener-reload gate driven by {@link DynamicCertificatesManager#computeChangedCertIds}.
+ * Each test name describes the high-level behaviour: when the returned set is empty, the
+ * reload skips {@code server.getListeners().reloadCurrentConfiguration(...)}; when it
+ * is non-empty, only listeners that bind one of those ids restart.
  */
 public class DynamicCertificatesManagerReloadGuardTest {
 
@@ -44,14 +45,14 @@ public class DynamicCertificatesManagerReloadGuardTest {
         final CertificateData stable = certWithKeystore("example.com", KEYSTORE_A);
         final Map<String, CertificateData> old = Map.of("example.com", stable);
         final Map<String, CertificateData> fresh = Map.of("example.com", certWithKeystore("example.com", KEYSTORE_A.clone()));
-        assertFalse(hasAnyBindingChange(old, fresh));
+        assertTrue(computeChangedCertIds(old, fresh).isEmpty());
     }
 
     @Test
     public void testReloadTriggersListenerOnKeystoreChange() {
         final Map<String, CertificateData> old = Map.of("example.com", certWithKeystore("example.com", KEYSTORE_A));
         final Map<String, CertificateData> fresh = Map.of("example.com", certWithKeystore("example.com", KEYSTORE_B));
-        assertTrue(hasAnyBindingChange(old, fresh));
+        assertEquals(Set.of("example.com"), computeChangedCertIds(old, fresh));
     }
 
     @Test
@@ -60,7 +61,7 @@ public class DynamicCertificatesManagerReloadGuardTest {
         final Map<String, CertificateData> fresh = Map.of(
                 "example.com", certWithKeystore("example.com", KEYSTORE_A.clone()),
                 "second.example.com", certWithKeystore("second.example.com", KEYSTORE_B));
-        assertTrue(hasAnyBindingChange(old, fresh));
+        assertEquals(Set.of("second.example.com"), computeChangedCertIds(old, fresh));
     }
 
     @Test
@@ -69,7 +70,7 @@ public class DynamicCertificatesManagerReloadGuardTest {
                 "example.com", certWithKeystore("example.com", KEYSTORE_A),
                 "second.example.com", certWithKeystore("second.example.com", KEYSTORE_B));
         final Map<String, CertificateData> fresh = Map.of("example.com", certWithKeystore("example.com", KEYSTORE_A.clone()));
-        assertTrue(hasAnyBindingChange(old, fresh));
+        assertEquals(Set.of("second.example.com"), computeChangedCertIds(old, fresh));
     }
 
     @Test
@@ -88,7 +89,7 @@ public class DynamicCertificatesManagerReloadGuardTest {
 
         final Map<String, CertificateData> old = Map.of("stuck.example.com", stuckPrev);
         final Map<String, CertificateData> fresh = Map.of("stuck.example.com", stuckTicked);
-        assertFalse(hasAnyBindingChange(old, fresh));
+        assertTrue(computeChangedCertIds(old, fresh).isEmpty());
     }
 
     @Test
@@ -97,7 +98,18 @@ public class DynamicCertificatesManagerReloadGuardTest {
         final CertificateData freshCert = certWithKeystoreAndSans("example.com", KEYSTORE_A.clone(), Set.of("other.example.com"));
         final Map<String, CertificateData> old = Map.of("example.com", oldCert);
         final Map<String, CertificateData> fresh = Map.of("example.com", freshCert);
-        assertTrue(hasAnyBindingChange(old, fresh));
+        assertEquals(Set.of("example.com"), computeChangedCertIds(old, fresh));
+    }
+
+    @Test
+    public void testReloadReturnsOnlyTheChangedIdsAmongStableOnes() {
+        final Map<String, CertificateData> old = Map.of(
+                "a.example.com", certWithKeystore("a.example.com", KEYSTORE_A),
+                "b.example.com", certWithKeystore("b.example.com", KEYSTORE_A));
+        final Map<String, CertificateData> fresh = Map.of(
+                "a.example.com", certWithKeystore("a.example.com", KEYSTORE_A.clone()),
+                "b.example.com", certWithKeystore("b.example.com", KEYSTORE_B));
+        assertEquals(Set.of("b.example.com"), computeChangedCertIds(old, fresh));
     }
 
     private static CertificateData certWithKeystore(final String domain, final byte[] keystoreData) {


### PR DESCRIPTION
## Context

Even with the binding-change gate in `DynamicCertificatesManager` (#23), every SSL listener on the box still restarts whenever the trigger does fire, because `Listeners.reloadConfiguration` short-circuits on reference equality of the config object — once `reloadCurrentConfiguration()` passes its own `currentConfiguration` back in, every SSL listener falls into the restart bucket. For a per-domain certificate renewal in a multi-tenant setup, that churns every unrelated listener.

## Approach

Carry the set of changed cert ids from the manager all the way to `Listeners.reloadConfiguration`, and gate the certificate-change branch on `ListeningChannel.bindsAnyOf(changedCertIds)`. Only listeners whose bound SNI keyset intersects the changed set fall into the restart bucket. The previous no-arg `reloadConfiguration` / `reloadCurrentConfiguration` keep their historical broad semantics for non-DCM callers (operator reloads, boot).

The DCM-side helper changes shape from `hasAnyBindingChange(old, new) → boolean` to `computeChangedCertIds(old, new) → Set<String>` — the same diff is computed but the result is now passed on instead of discarded after the gate decision.

Stacks on #23.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized SSL listener restart logic to selectively reload only listeners affected by certificate changes, reducing unnecessary restarts and improving configuration reload efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NiccoMlt/carapaceproxy/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->