### PR TITLE
Document the global-SNI certificate model on the listeners

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/core/Listeners.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/Listeners.java
@@ -125,6 +125,10 @@ public class Listeners {
             final EndpointKey hostPort = channel.getKey();
             final NetworkListenerConfiguration actualListenerConfig = currentConfiguration.getListener(hostPort);
             final NetworkListenerConfiguration newConfigurationForListener = newConfiguration.getListener(hostPort);
+            // Certificate-only reload: the dynamic-certificate manager re-applies the current configuration
+            // (same object reference) after a certificate changes. Every SSL listener serves the full
+            // certificate set via SNI (see ListeningChannel#sslContexts), so there is no per-listener subset
+            // to narrow to — any certificate change rebinds every SSL listener.
             final boolean isReloadCertificate = newConfiguration == currentConfiguration && newConfigurationForListener.ssl();
             if (newConfigurationForListener == null) {
                 LOG.info("listener: {} is to be shut down", hostPort);

--- a/carapace-server/src/main/java/org/carapaceproxy/core/ListeningChannel.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/core/ListeningChannel.java
@@ -51,6 +51,16 @@ public class ListeningChannel {
     private final int localPort;
     private final NetworkListenerConfiguration config;
     private final Counter.Child totalRequests;
+    /**
+     * SSL contexts this listener can present, keyed by certificate id.
+     * <p>
+     * Built from the <em>global</em> {@link RuntimeServerConfiguration#getCertificates()} map, so it is the
+     * same set for every SSL listener: a listener serves the full certificate set and selects per connection
+     * by SNI (see {@link #apply}). A {@link NetworkListenerConfiguration} carries no per-listener certificate
+     * list — only a single {@link NetworkListenerConfiguration#defaultCertificate()} for clients that send no
+     * SNI. Consequently there is no listener-specific certificate subset: when any certificate's binding
+     * changes, every SSL listener must rebind.
+     */
     private final Map<String, SslContext> sslContexts;
     private final File basePath;
     private final RuntimeServerConfiguration currentConfiguration;


### PR DESCRIPTION
## Context

A reviewer reasonably read the listener-reload path as if each listener bound a distinct subset of certificates, and proposed narrowing the certificate-triggered reload to only the listeners that bind a changed cert. They don't: `ListeningChannel` builds its SSL contexts from the global `RuntimeServerConfiguration.getCertificates()` map and selects per connection by SNI, and a `NetworkListenerConfiguration` carries only a single `defaultCertificate` — there is no per-listener certificate list. So any certificate change must rebind every SSL listener, and there is nothing to narrow.

## Approach

Document the assumption where it would otherwise be re-derived incorrectly: a javadoc on `ListeningChannel.sslContexts` describing the global-SNI model, and a short comment at the certificate-reload classification in `Listeners`. Comments only, no behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced internal code documentation with clarifications on SSL certificate reload behavior and context management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NiccoMlt/carapaceproxy/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->