### PR TITLE
fix: only restart listeners when a certificate actually changes

### DIFF
--- a/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
+++ b/carapace-server/src/main/java/org/carapaceproxy/server/certificates/DynamicCertificatesManager.java
@@ -682,12 +682,42 @@ public class DynamicCertificatesManager implements Runnable {
             }
             var oldCertificates = this.certificates;
             this.certificates = newCertificates; // only certificates/domains specified in the config have to be managed.
-            server.getListeners().reloadCurrentConfiguration();
+            // Only restart listeners when a certificate's keystore bytes actually changed. A perpetually
+            // failing ACME cert flips transient state (attemptsCount/message) every cycle but its TLS
+            // material is unchanged; restarting the SSL listeners on every such tick flaps the bound ports
+            // for nothing.
+            if (keystoreDataChanged(oldCertificates, newCertificates)) {
+                server.getListeners().reloadCurrentConfiguration();
+            } else {
+                LOG.debug("Certificates reloaded from db with no keystore change; skipping listener reload");
+            }
             // storing certificates on local path
             storeLocalCertificates(newCertificates.values(), oldCertificates);
         } catch (GeneralSecurityException | MalformedURLException | InterruptedException | ConfigurationNotValidException e) {
             throw new DynamicCertificatesManagerException("Unable to load dynamic certificates from db.", e);
         }
+    }
+
+    /**
+     * Tell whether the keystore bytes a listener would serve changed between two certificate snapshots.
+     * The two maps share the same key set here (the new snapshot is built by walking the old one), so a
+     * missing previous entry is treated as a change to cover first issuance. Package-private to be unit
+     * testable.
+     *
+     * @param oldCerts the previous certificate snapshot
+     * @param newCerts the freshly reloaded certificate snapshot
+     * @return {@code true} if any domain's keystore bytes differ
+     */
+    static boolean keystoreDataChanged(Map<String, CertificateData> oldCerts, Map<String, CertificateData> newCerts) {
+        for (Entry<String, CertificateData> entry : newCerts.entrySet()) {
+            CertificateData prev = oldCerts.get(entry.getKey());
+            byte[] prevKeystore = prev == null ? null : prev.getKeystoreData();
+            byte[] newKeystore = entry.getValue() == null ? null : entry.getValue().getKeystoreData();
+            if (!Arrays.equals(prevKeystore, newKeystore)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void storeLocalCertificates(Collection<CertificateData> newCertificates, Map<String, CertificateData> oldCertificates) {

--- a/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerKeystoreDiffTest.java
+++ b/carapace-server/src/test/java/org/carapaceproxy/server/certificates/DynamicCertificatesManagerKeystoreDiffTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.carapaceproxy.server.certificates;
+
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.AVAILABLE;
+import static org.carapaceproxy.server.certificates.DynamicCertificateState.WAITING;
+import static org.carapaceproxy.server.certificates.DynamicCertificatesManager.keystoreDataChanged;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import java.util.HashMap;
+import java.util.Map;
+import org.carapaceproxy.configstore.CertificateData;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link DynamicCertificatesManager#keystoreDataChanged(Map, Map)}, the gate that keeps a
+ * still-failing ACME certificate from restarting the SSL listeners on every reload cycle.
+ */
+public class DynamicCertificatesManagerKeystoreDiffTest {
+
+    private static CertificateData cert(final String domain, final byte[] keystoreData) {
+        final CertificateData data = new CertificateData(domain, null, keystoreData == null ? WAITING : AVAILABLE);
+        data.setKeystoreData(keystoreData);
+        return data;
+    }
+
+    private static Map<String, CertificateData> snapshot(final CertificateData... certs) {
+        final Map<String, CertificateData> map = new HashMap<>();
+        for (final CertificateData cert : certs) {
+            map.put(cert.getDomain(), cert);
+        }
+        return map;
+    }
+
+    @Test
+    public void failingCertWithNoKeystoreBothCyclesIsNotAChange() {
+        // The loop case: a perpetually failing cert keeps null keystore bytes across cycles.
+        final Map<String, CertificateData> old = snapshot(cert("example.com", null));
+        final Map<String, CertificateData> fresh = snapshot(cert("example.com", null));
+        assertFalse(keystoreDataChanged(old, fresh));
+    }
+
+    @Test
+    public void firstIssuanceIsAChange() {
+        final Map<String, CertificateData> old = snapshot(cert("example.com", null));
+        final Map<String, CertificateData> fresh = snapshot(cert("example.com", new byte[]{1, 2, 3}));
+        assertTrue(keystoreDataChanged(old, fresh));
+    }
+
+    @Test
+    public void sameKeystoreBytesIsNotAChange() {
+        final Map<String, CertificateData> old = snapshot(cert("example.com", new byte[]{1, 2, 3}));
+        final Map<String, CertificateData> fresh = snapshot(cert("example.com", new byte[]{1, 2, 3}));
+        assertFalse(keystoreDataChanged(old, fresh));
+    }
+
+    @Test
+    public void renewedKeystoreBytesIsAChange() {
+        final Map<String, CertificateData> old = snapshot(cert("example.com", new byte[]{1, 2, 3}));
+        final Map<String, CertificateData> fresh = snapshot(cert("example.com", new byte[]{4, 5, 6}));
+        assertTrue(keystoreDataChanged(old, fresh));
+    }
+
+    @Test
+    public void oneChangedDomainAmongStableOnesIsAChange() {
+        final Map<String, CertificateData> old = snapshot(
+                cert("stable.com", new byte[]{1, 2, 3}),
+                cert("renewing.com", new byte[]{4, 5, 6}));
+        final Map<String, CertificateData> fresh = snapshot(
+                cert("stable.com", new byte[]{1, 2, 3}),
+                cert("renewing.com", new byte[]{7, 8, 9}));
+        assertTrue(keystoreDataChanged(old, fresh));
+    }
+
+    @Test
+    public void missingPreviousEntryIsAChange() {
+        final Map<String, CertificateData> old = snapshot();
+        final Map<String, CertificateData> fresh = snapshot(cert("example.com", new byte[]{1, 2, 3}));
+        assertTrue(keystoreDataChanged(old, fresh));
+    }
+}


### PR DESCRIPTION
The dynamic certificate manager reloads the listeners on every poll. When a domain's only change is a failing ACME challenge bumping its attempt count, that reload reuses the same configuration instance, so every SSL listener is classified as needing a restart and gets stopped and rebound on each cycle — flapping the bound ports for no real change. A previous attempt to address this (commit 289ee80b) instead forced the restart on every same-instance reload, turning the periodic poll into a continuous listener-restart loop on hosts with a stuck certificate.

This gates the reload on the certificate keystore bytes: the listeners are reloaded only when a domain's keystore actually differs from the previous snapshot. A genuine issuance or renewal still triggers exactly one reload; a perpetually failing challenge no longer triggers any.

Scope is intentionally limited to the trigger (the certificate-manager side). The complementary narrowing — restarting only the listeners that bind a changed certificate, rather than all SSL listeners on a real change — is left as a follow-up.

Adds a unit test covering the keystore-diff cases (failing both cycles, first issuance, unchanged, renewal, mixed, missing previous).

Refs diennea/carapaceproxy#528.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Certificate manager now selectively reloads proxy listeners only when keystore bytes change for managed domains, reducing unnecessary reconfigurations.

* **Tests**
  * Added comprehensive test suite validating keystore change detection across various certificate lifecycle scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->